### PR TITLE
Static variables should be qualified by type name.

### DIFF
--- a/src/main/java/io/crossroads/Tester.java
+++ b/src/main/java/io/crossroads/Tester.java
@@ -20,7 +20,7 @@ public class Tester {
         System.out.println("Starting Tester");
         xs = (XsLibrary) Native.loadLibrary("xs_d", XsLibrary.class);
         ctx = xs.xs_init();
-        sock = xs.xs_socket(ctx, xs.XS_REQ);
+        sock = xs.xs_socket(ctx, XsLibrary.XS_REQ);
     }
 
     public void dispose() {
@@ -50,7 +50,7 @@ public class Tester {
 
     private void testPoll() {
         XsPollItem[] items = new XsPollItem[1];
-        items[0] = new XsPollItem(sock, null, xs.XS_POLLIN);
+        items[0] = new XsPollItem(sock, null, XsLibrary.XS_POLLIN);
         int n = xs.xs_poll(items, 1, 0);
         System.out.printf("XS polled socket, got %d events\n",
                           n);

--- a/src/perf/java/io/crossroads/local_lat.java
+++ b/src/perf/java/io/crossroads/local_lat.java
@@ -36,7 +36,7 @@ public class local_lat {
         }
         System.out.printf("XS inited\n");
 
-        s = xs.xs_socket(ctx, xs.XS_REP);
+        s = xs.xs_socket(ctx, XsLibrary.XS_REP);
         if (s == null) {
             System.out.printf("error in xs_socket: %s\n",
                               xs.xs_strerror(xs.xs_errno()));

--- a/src/perf/java/io/crossroads/local_thr.java
+++ b/src/perf/java/io/crossroads/local_thr.java
@@ -41,7 +41,7 @@ public class local_thr {
         }
         System.out.printf("XS inited\n");
 
-        s = xs.xs_socket(ctx, xs.XS_PULL);
+        s = xs.xs_socket(ctx, XsLibrary.XS_PULL);
         if (s == null) {
             System.out.printf("error in xs_socket: %s\n",
                               xs.xs_strerror(xs.xs_errno()));

--- a/src/perf/java/io/crossroads/remote_lat.java
+++ b/src/perf/java/io/crossroads/remote_lat.java
@@ -42,7 +42,7 @@ public class remote_lat {
         }
         System.out.printf("XS inited\n");
 
-        s = xs.xs_socket(ctx, xs.XS_REQ);
+        s = xs.xs_socket(ctx, XsLibrary.XS_REQ);
         if (s == null) {
             System.out.printf("error in xs_socket: %s\n",
                               xs.xs_strerror(xs.xs_errno()));

--- a/src/perf/java/io/crossroads/remote_thr.java
+++ b/src/perf/java/io/crossroads/remote_thr.java
@@ -38,7 +38,7 @@ public class remote_thr {
         }
         System.out.printf("XS inited\n");
 
-        s = xs.xs_socket(ctx, xs.XS_PUSH);
+        s = xs.xs_socket(ctx, XsLibrary.XS_PUSH);
         if (s == null) {
             System.out.printf("error in xs_socket: %s\n",
                               xs.xs_strerror(xs.xs_errno()));


### PR DESCRIPTION
Fixes some trivial compilation warnings.
